### PR TITLE
fix: do not set set session replay properties for events not in current session

### DIFF
--- a/Sources/AmplitudeSwiftSessionReplayPlugin/AmplitudeSwiftSessionReplayPlugin.swift
+++ b/Sources/AmplitudeSwiftSessionReplayPlugin/AmplitudeSwiftSessionReplayPlugin.swift
@@ -58,7 +58,9 @@ import AmplitudeSessionReplay
     }
 
     public func execute(event: BaseEvent) -> BaseEvent? {
-        guard let sessionReplay = sessionReplay else {
+        guard let sessionReplay = sessionReplay,
+              sessionReplay.sessionId == event.sessionId,
+              sessionReplay.deviceId == event.deviceId else {
             return event
         }
 

--- a/Sources/AmplitudeiOSSessionReplayMiddleware/AmplitudeiOSSessionReplayMiddleware.swift
+++ b/Sources/AmplitudeiOSSessionReplayMiddleware/AmplitudeiOSSessionReplayMiddleware.swift
@@ -51,7 +51,9 @@ import AmplitudeSessionReplay
     }
 
     public func run(_ payload: AMPMiddlewarePayload, next: @escaping AMPMiddlewareNext) {
-        guard let sessionReplay = sessionReplay else {
+        guard let sessionReplay = sessionReplay,
+              sessionReplay.sessionId == payload.event["session_id"] as? CLongLong,
+              sessionReplay.deviceId == payload.event["device_id"] as? String else {
             return
         }
 


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

The Amplitude-iOS middleware and Amplitude-Swift plugin get sessionId from the sdk itself, not from the latest fired event. For events like session ended that are sent with session ids that are not part of the session, we were still appending the active session replay properties, which conflicted with session replay properties from events from earlier in the session.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
