### PR TITLE
fix: update min core version

### DIFF
--- a/AmplitudeSessionReplay.podspec
+++ b/AmplitudeSessionReplay.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.ios.deployment_target  = '13.0'
   s.vendored_frameworks = "Frameworks/AmplitudeSessionReplay.xcframework"
 
-  s.dependency 'AmplitudeCore', '>= 1.0.10', '< 2.0.0'
+  s.dependency 'AmplitudeCore', '>= 1.0.11', '< 2.0.0'
 end

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package(
             targets: ["AmplitudeSegmentSessionReplayPlugin"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.0.10"),
+        .package(url: "https://github.com/amplitude/AmplitudeCore-Swift.git", from: "1.0.11"),
         .package(url: "https://github.com/amplitude/Amplitude-iOS.git", from: "8.22.0"),
         .package(url: "https://github.com/segmentio/analytics-swift", "1.5.0"..<"2.0.0"),
     ],


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

sets min version of core to the (working for cocoapods) 1.0.11

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
