### PR TITLE
fix: update lint runner to macos-14 due to github deprecation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,12 +8,15 @@ on:
 
 jobs:
   lint:
-    runs-on: macos-13
+    runs-on: macos-14
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set Xcode 15
+      - name: Set Xcode 16
         run: |
-          sudo xcode-select -switch /Applications/Xcode_15.2.app
+          sudo xcode-select -switch /Applications/Xcode_16.1.app
+      - name: Install SwiftLint
+        run: |
+          brew install swiftlint
       - name: Lint
         run: swiftlint --strict # force to fix warnings too


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

Fixes lint jobs being cancelled by https://github.com/actions/runner-images/issues/13046

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
