### PR TITLE
fix: enable log api to be accessed from objc

### DIFF
--- a/Sources/AmplitudeiOSSessionReplayMiddleware/AmplitudeiOSSessionReplayMiddleware.swift
+++ b/Sources/AmplitudeiOSSessionReplayMiddleware/AmplitudeiOSSessionReplayMiddleware.swift
@@ -108,15 +108,15 @@ import AmplitudeSessionReplay
         sessionReplay?.stop()
     }
 
-    public func start() {
+    @objc public func start() {
         sessionReplay?.start()
     }
 
-    public func stop() {
+    @objc public func stop() {
         sessionReplay?.stop()
     }
 
-    public func recordLog(level: RecordLogLevel, message: String?, date: Date = Date()) {
+    @objc public func recordLog(level: RecordLogLevel, message: String?, date: Date = Date()) {
         sessionReplay?.recordLog(level: level, message: message, date: date)
     }
 }


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude SDK Template repository! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

fix https://github.com/amplitude/AmplitudeSessionReplay-iOS/issues/49

### Checklist

* [X] Does your PR title have the correct [title format](https://github.com/amplitude/Amplitude-SDK-Template/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  no
