### PR TITLE
ci(release): make pod trunk pushes idempotent and retry-safe

### DIFF
--- a/release.config.js
+++ b/release.config.js
@@ -52,16 +52,16 @@ module.exports = {
       "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
     }],
     ["@semantic-release/exec", {
-      "publishCmd": "pod trunk push AmplitudeSessionReplay.podspec --allow-warnings",
+      "publishCmd": "./scripts/pod-trunk-push.sh AmplitudeSessionReplay.podspec",
     }],
     ["@semantic-release/exec", {
       "publishCmd": "pod repo update",
     }],
     ["@semantic-release/exec", {
-      "publishCmd": "pod trunk push AmplitudeiOSSessionReplayMiddleware.podspec --allow-warnings --synchronous",
+      "publishCmd": "./scripts/pod-trunk-push.sh AmplitudeiOSSessionReplayMiddleware.podspec",
     }],
     ["@semantic-release/exec", {
-      "publishCmd": "pod trunk push AmplitudeSwiftSessionReplayPlugin.podspec --allow-warnings --synchronous",
+      "publishCmd": "./scripts/pod-trunk-push.sh AmplitudeSwiftSessionReplayPlugin.podspec",
     }],
   ],
 }

--- a/scripts/pod-trunk-push.sh
+++ b/scripts/pod-trunk-push.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Publish one podspec to CocoaPods trunk, deciding success from the trunk API rather
+# than from the exit code of `pod trunk push`.
+#
+# Why: trunk can report `Calling the GitHub commit API timed out` *after* it has
+# already committed the spec. `pod trunk push` then exits 1, which aborts the rest of
+# the semantic-release publish pipeline and silently skips the pods queued behind it.
+# That is what happened in 0.12.6 (AmplitudeSessionReplay went out, the two wrapper
+# pods did not) and, going by the versions missing from trunk, in 0.12.3 as well.
+#
+# Deliberately not `set -e`: a failing push has to be inspected, not fatal.
+set -uo pipefail
+
+podspec=${1:-}
+
+if [ -z "$podspec" ] || [ ! -f "$podspec" ]; then
+  echo "Usage: $0 <podspec>"
+  exit 1
+fi
+
+attempts=${POD_PUSH_ATTEMPTS:-3}
+retry_delay=${POD_PUSH_RETRY_DELAY:-30}
+
+name=$(grep -E "^[[:space:]]*s\.name" "$podspec" | grep -oE '"[^"]+"' | tr -d '"')
+version=$(grep -E "^amplitude_version" "$podspec" | grep -oE '"[^"]+"' | tr -d '"')
+
+if [ -z "$name" ] || [ -z "$version" ]; then
+  echo "✗ Could not read pod name / version from $podspec"
+  exit 1
+fi
+
+# trunk is the source of truth for "does this version exist". Absent (or unreachable)
+# is reported as not published, so a network blip never fakes a successful release.
+is_published() {
+  curl -sf --max-time 30 "https://trunk.cocoapods.org/api/v1/pods/${name}" \
+    | grep -q "\"name\": *\"${version}\""
+}
+
+if is_published; then
+  echo "✓ $name $version is already on trunk — nothing to push"
+  exit 0
+fi
+
+# Arithmetic loop, not `seq 1 $attempts`: BSD seq counts *down* when the end is below
+# the start, so a zero/garbled attempt count would silently retry instead of failing.
+for (( attempt = 1; attempt <= attempts; attempt++ )); do
+  echo "→ pod trunk push $podspec (attempt $attempt/$attempts)"
+  if pod trunk push "$podspec" --allow-warnings --synchronous; then
+    echo "✓ $name $version published"
+    exit 0
+  fi
+
+  # The push may have landed despite the reported failure. Give trunk a moment to
+  # finish the commit it was already making, then ask the API instead of guessing.
+  echo "  push reported failure — re-checking trunk in ${retry_delay}s"
+  sleep "$retry_delay"
+  if is_published; then
+    echo "✓ $name $version is on trunk despite the reported failure — treating as published"
+    exit 0
+  fi
+done
+
+echo "✗ Failed to publish $name $version after $attempts attempt(s)"
+exit 1


### PR DESCRIPTION
## Why

The 0.12.6 release [failed](https://github.com/amplitude/AmplitudeSessionReplay-iOS/actions/runs/31546446266/job/93959905800) on the first publish step:

```
pod trunk push AmplitudeSessionReplay.podspec --allow-warnings   → exit 1
[!] Calling the GitHub commit API timed out.
```

The spec had in fact been committed — `AmplitudeSessionReplay 0.12.6` is on trunk (`23:30:53 UTC`) and on the CDN. But the non-zero exit aborted the rest of the publish pipeline, so the three steps queued behind it never ran and **`AmplitudeiOSSessionReplayMiddleware` and `AmplitudeSwiftSessionReplayPlugin` were never published**. Both are missing `0.12.3` too, so this has happened before and went unnoticed.

(0.12.6 has since been backfilled manually; all three pods are live.)

## What

`scripts/pod-trunk-push.sh` decides success from the trunk API rather than from the exit code:

- already published → skip, so re-running a release is a no-op instead of a duplicate-entry error
- push reported failure → wait, re-check trunk, and only retry if the version really isn't there (3 attempts, `POD_PUSH_ATTEMPTS` / `POD_PUSH_RETRY_DELAY` overridable)
- genuinely unpublished after all attempts → exit 1, so a real failure still stops the release

`release.config.js` routes all three pushes through it. This also unifies `--synchronous`, which only the two wrapper pods had.

## Validation

Run against the current `main` podspecs (all three already at 0.12.6):

| case | result |
|---|---|
| already published ×3 | `✓ … already on trunk — nothing to push`, exit 0 |
| unpublished version (`9.9.9`) | attempts the push, re-checks trunk, exit 1 — no false success |
| `POD_PUSH_ATTEMPTS=0` | exits 1 without pushing |
| no/missing argument | usage, exit 1 |

The last two caught real bugs in review: BSD `seq 1 0` counts *down*, so `seq` was replaced with an arithmetic loop, and `$1` under `set -u` aborted before the usage check.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the CocoaPods publish path in the release pipeline. Logic is defensive and well-scoped, but a bug here could skip or falsely succeed pod publishes.
> 
> **Overview**
> Fixes CocoaPods publish failures that aborted the semantic-release pipeline after a false-negative `pod trunk push` exit (timeout after the spec was already committed), which previously left wrapper pods unpublished.
> 
> Adds `scripts/pod-trunk-push.sh`, which treats the trunk API as the source of truth: skips already-published versions, retries failed pushes, and only exits non-zero if the version is still missing. `release.config.js` routes all three podspec publishes through it and unifies `--synchronous` across them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05affd32e57a3ba25fa83a0f9d0acdbeb0866b4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->